### PR TITLE
Fix: Add missing customInputs and providerCustomInputs to avoid CMP backend error

### DIFF
--- a/modules/vcd_swisscom_vm/schemas/swisscom_vm.json.tpl
+++ b/modules/vcd_swisscom_vm/schemas/swisscom_vm.json.tpl
@@ -62,6 +62,8 @@
       "fileSystemMount": "Hard Disk 2",
       "storagePolicy": "${storagePolicy}",
       "type": "5"
-    }
+    },
+  "customInputs": [],
+  "providerCustomInputs": []
   ]
 }

--- a/modules/vcd_swisscom_vm/schemas/swisscom_vm.json.tpl
+++ b/modules/vcd_swisscom_vm/schemas/swisscom_vm.json.tpl
@@ -62,8 +62,8 @@
       "fileSystemMount": "Hard Disk 2",
       "storagePolicy": "${storagePolicy}",
       "type": "5"
-    },
+    }
+  ],
   "customInputs": [],
   "providerCustomInputs": []
-  ]
 }


### PR DESCRIPTION
This fixes a backend NullPointerException caused by missing `customInputs` and `providerCustomInputs` in the VM RDE payload.

Without these fields, the Swisscom CMP backend fails with the error:
> RDE with id: urn:vcloud:entity:swisscom:vm:<id> is not valid. VM Creation process canceled. Cannot invoke "java.util.List.forEach(java.util.function.Consumer)" because the return value of "com.swisscom.itclouds.cmp.iaas.mod....

This change ensures both fields are always sent as empty arrays (`[]`) when unused.
